### PR TITLE
Bump shiro-spring in /16.Spring-Boot-Shiro-Thymeleaf-Tag

### DIFF
--- a/16.Spring-Boot-Shiro-Thymeleaf-Tag/pom.xml
+++ b/16.Spring-Boot-Shiro-Thymeleaf-Tag/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 		    <groupId>org.apache.shiro</groupId>
 		    <artifactId>shiro-spring</artifactId>
-		    <version>1.4.0</version>
+		    <version>1.7.1</version>
 		</dependency>
 		
 		<!-- shiro ehcache -->


### PR DESCRIPTION
Bumps shiro-spring from 1.4.0 to 1.7.1.

---
updated-dependencies:
- dependency-name: org.apache.shiro:shiro-spring
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>